### PR TITLE
Reverting docker-compose to use redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 version: '2'
 services:
-    memcached:
+    redis:
         restart: always
-        image: memcached:alpine
+        image: redis:alpine
         ports:
-            - "11211:11211"
+            - "6379:6379"
     web:
         restart: always
         build: .
         ports:
             - "8000:80"
         links:
-            - memcached
+            - redis
 


### PR DESCRIPTION
memcached was countermeasure for memory outage when it was running on a VPS. 
Now the site environment brought back to Heroku so redis should be used in development environment.